### PR TITLE
Login Connection Bug

### DIFF
--- a/cosc360-rsvp/server/src/modules/routes/loginRouter.js
+++ b/cosc360-rsvp/server/src/modules/routes/loginRouter.js
@@ -3,6 +3,6 @@ import { processLogin } from "../controllers/loginController.js";
 
 const router = express.Router();
 
-router.post("/login", processLogin);
+router.post("/", processLogin);
 
 export default router;


### PR DESCRIPTION
LoginRouter.js had the route as /login which was already handled by Login.js so it was making the route /api/login/login which was invalid. 

That's the only change here. 