### PR TITLE
Save event, Get all saved/RSVP'd events

### DIFF
--- a/cosc360-rsvp/server/src/modules/controllers/rsvpController.js
+++ b/cosc360-rsvp/server/src/modules/controllers/rsvpController.js
@@ -1,8 +1,14 @@
 import * as rsvpService from "../services/rsvpServices.js";
 
 export const createRSVP = async (req, res) => {
+    const userId = req.user?.id;
+
+    if (!userId) {
+        return res.status(401).json({ error: "User not authenticated" });
+    }
+
     try {
-        const newRsvp = await rsvpService.createRSVP(req.body);
+        const newRsvp = await rsvpService.createRSVP({ ...req.body, userId });
         res.status(201).json({ message: "RSVP created successfully!", event: newRsvp });
     } catch (error) {
         if (error.message === "You have already RSVP'd to this event!") {
@@ -12,3 +18,49 @@ export const createRSVP = async (req, res) => {
         res.status(500).json({ error: "Could not create RSVP" });
     }
 }
+
+export const updateRSVP = async (req, res) => {
+    const { eventId } = req.params;
+    const { status } = req.body;
+    const userId = req.user?.id;
+
+    if (!userId) {
+        return res.status(401).json({ error: "User not authenticated" });
+    }
+
+    try {
+        const updatedRsvp = await rsvpService.updateRSVP({ eventId, userId, status });
+        res.status(200).json({ message: "RSVP updated successfully!", event: updatedRsvp });
+    } catch (error) {
+        if (error.message === "Invalid RSVP status" || error.message === "RSVP status is required") {
+            return res.status(400).json({ error: error.message });
+        }
+
+        if (error.message === "RSVP not found") {
+            return res.status(404).json({ error: error.message });
+        }
+
+        res.status(500).json({ error: "Could not update RSVP" });
+    }
+}
+
+export const getRSVPsByStatus = async (req, res) => {
+    const userId = req.user?.id;
+    const { status } = req.query;
+
+    if (!userId) {
+        return res.status(401).json({ error: "User not authenticated" });
+    }
+
+    try {
+        const events = await rsvpService.getRSVPsByStatus(userId, status);
+        res.status(200).json({ events });
+    } catch (error) {
+        if (error.message === "Invalid RSVP status" || error.message === "RSVP status is required") {
+            return res.status(400).json({ error: error.message });
+        }
+
+        res.status(500).json({ error: `Could not retrieve ${status} events` });
+    }
+}
+

--- a/cosc360-rsvp/server/src/modules/middleware.js
+++ b/cosc360-rsvp/server/src/modules/middleware.js
@@ -1,0 +1,10 @@
+export const requireUser = (req, res, next) => {
+	const userId = req.header("x-user-id");
+
+	if (!userId) {
+		return res.status(401).json({ error: "User not authenticated" });
+	}
+
+	req.user = { id: userId };
+	next();
+};

--- a/cosc360-rsvp/server/src/modules/model/rsvp.model.js
+++ b/cosc360-rsvp/server/src/modules/model/rsvp.model.js
@@ -4,8 +4,10 @@ const rsvpSchema = new Schema(
     {
         eventId: { type: Schema.Types.ObjectId, ref: "Event", required: true },
         userId: { type: Schema.Types.ObjectId, ref: "User", required: true },
-        status: { type: String, required: true }, // 'yes', 'no', 'saved'
+        status: { type: String, enum: ["yes", "no", "saved"], required: true },
     }
 );
+
+rsvpSchema.index({ eventId: 1, userId: 1 }, { unique: true });
 
 export const RSVPModel = mongoose.model("RSVP", rsvpSchema);

--- a/cosc360-rsvp/server/src/modules/repository/rsvpRepository.js
+++ b/cosc360-rsvp/server/src/modules/repository/rsvpRepository.js
@@ -5,6 +5,16 @@ export async function createRSVP(rsvpData) {
     return rsvp.toJSON();
 }
 
+export async function updateRSVP(eventId, userId, status) {
+    const rsvp = await RSVPModel.findOneAndUpdate({eventId, userId}, { status }, { new: true, runValidators: true });
+
+    if (!rsvp) {
+        throw new Error("RSVP not found");
+    }
+
+    return rsvp.toJSON();
+}
+
 export async function findRSVP(eventId, userId) {
     return await RSVPModel.findOne(
         {
@@ -12,4 +22,13 @@ export async function findRSVP(eventId, userId) {
             userId: userId
         }
     )
+}
+
+export async function findEventsByStatus(userId, status) {
+    return await RSVPModel.find(
+        {
+            userId: userId,
+            status: status
+        }
+    ).populate("eventId");
 }

--- a/cosc360-rsvp/server/src/modules/routes/rsvpRoutes.js
+++ b/cosc360-rsvp/server/src/modules/routes/rsvpRoutes.js
@@ -1,8 +1,16 @@
 import express from "express";
 import * as rsvpController from "../controllers/rsvpController.js";
+import { requireUser } from "../middleware.js";
 
 const router = express.Router();
 
+router.use(requireUser);
+
+router.get("/", (req, res) => {
+    res.status(200).json({ message: "RSVP route is working!" });
+});
+router.get("/events", rsvpController.getRSVPsByStatus);
 router.post("/", rsvpController.createRSVP);
+router.put("/:eventId", rsvpController.updateRSVP);
 
 export default router;

--- a/cosc360-rsvp/server/src/modules/services/rsvpServices.js
+++ b/cosc360-rsvp/server/src/modules/services/rsvpServices.js
@@ -1,6 +1,20 @@
 import * as rsvpRepository from "../repository/rsvpRepository.js";
 
+const VALID_STATUSES = new Set(["yes", "no", "saved"]);
+
+function validateStatus(status) {
+    if (!status) {
+        throw new Error("RSVP status is required");
+    }
+
+    if (!VALID_STATUSES.has(status)) {
+        throw new Error("Invalid RSVP status");
+    }
+}
+
 export async function createRSVP(rsvpData) {
+    validateStatus(rsvpData.status);
+
     const existingRSVP = await rsvpRepository.findRSVP(rsvpData.eventId, rsvpData.userId);
 
     if (existingRSVP) {
@@ -8,4 +22,16 @@ export async function createRSVP(rsvpData) {
     }
 
     return await rsvpRepository.createRSVP(rsvpData);
+}
+
+export async function updateRSVP(rsvpData) {
+    validateStatus(rsvpData.status);
+
+    return await rsvpRepository.updateRSVP(rsvpData.eventId, rsvpData.userId, rsvpData.status);
+}
+
+export async function getRSVPsByStatus(userId, status) {
+    validateStatus(status);
+
+    return await rsvpRepository.findEventsByStatus(userId, status);
 }


### PR DESCRIPTION
In this PR I have added the ability for users to save events (only once), and get all of their saved and RSVP'd events according to their userId.

Changes:
- Added the ability for the system to get the unique userId from the header in `middleware.js`.
- Used this in all of the RSVP functions to validate the user and to get/update their corresponding RSVPs.
- The get events endpoint takes in a query string for the status, which is then used to get the corresponding RSVPs within the scope of the active user.
- Added a `validateStatus()` method to ensure that the passed `status` matches one of the enum values required by the model.