### PR TITLE
Adds Authentication Context

### DIFF
--- a/cosc360-rsvp/client/src/app/App.jsx
+++ b/cosc360-rsvp/client/src/app/App.jsx
@@ -8,6 +8,7 @@ import MyEvents from "../pages/myEvents.jsx";
 import SavedEvents from "../pages/savedEvents.jsx";
 import Login from "../features/login/Login.jsx";
 import ResetPassword from "../features/login/ResetPassword.jsx";
+import ProtectedRoute from "../components/ProtectedRoute.jsx";
 
 
 /* Create a page for each main view and then link it here! It will be accessible at localhost/pageName */

--- a/cosc360-rsvp/client/src/app/App.jsx
+++ b/cosc360-rsvp/client/src/app/App.jsx
@@ -17,17 +17,19 @@ function App() {
   return (
     <>
       <Routes>
+
+        {/* Public Routes - Unregistered User Pages to Go here too?*/}
         <Route path="/register" element={<RegisterForm />} />
-        <Route path="/home" element={<Homepage />} />
-        <Route path="/adminManage" element={<AdminUserManage/>} />
-        <Route path="/event/:id" element={<SingleEventPage />} />
-
-        <Route path="/myevents" element={<MyEvents />} />
-        <Route path="/savedevents" element={<SavedEvents />} />
-
         <Route path="/login" element={<Login />}/>
-
         <Route path="/reset-password" element={<ResetPassword/>} />
+
+
+        {/* Protected Routes - Require Auth to Access*/}
+        <Route path="/myevents" element={<ProtectedRoute><MyEvents /></ProtectedRoute>} />
+        <Route path="/savedevents" element={<ProtectedRoute><SavedEvents /></ProtectedRoute>} />
+        <Route path="/home" element={<ProtectedRoute><Homepage /></ProtectedRoute>} />
+        <Route path="/adminManage" element={<ProtectedRoute><AdminUserManage/></ProtectedRoute>} />
+        <Route path="/event/:id" element={<ProtectedRoute><SingleEventPage /></ProtectedRoute>} />
 
       </Routes> 
       

--- a/cosc360-rsvp/client/src/components/ProtectedRoute.jsx
+++ b/cosc360-rsvp/client/src/components/ProtectedRoute.jsx
@@ -1,0 +1,7 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+export default function ProtectedRoute({ children }) {
+    const { user } = useAuth();
+    return user ? children : <Navigate to="/login" replace />;
+}

--- a/cosc360-rsvp/client/src/components/sidebar.jsx
+++ b/cosc360-rsvp/client/src/components/sidebar.jsx
@@ -1,6 +1,7 @@
 import { Calendar, LogOutIcon, Save, FileBadge } from 'lucide-react';
 import "../css/sidebar.css";
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from "../context/AuthContext.jsx";
 
 const menuItems = [
     { icon: Calendar, label: "Browse Events" },
@@ -20,6 +21,12 @@ const MenuItem = ({ icon: Icon, label, clickItem }) => {
 
 function Sidebar({ user, profilePicture }) {
     const navigate = useNavigate();
+    const { logout } = useAuth();
+
+    function handleLogout(){
+        logout();
+        navigate('/login');
+    }
 
     function handleSidebarClick(index){
         if (index === 0) {
@@ -57,7 +64,8 @@ function Sidebar({ user, profilePicture }) {
             <div className="logout">
                 <MenuItem
                     icon={LogOutIcon}
-                    label="Logout" /> {/*TODO: add logout functionality with clickItem call once implemented */}
+                    label="Logout"
+                    clickItem={handleLogout} /> 
             </div>
         </div>
     

--- a/cosc360-rsvp/client/src/context/AuthContext.jsx
+++ b/cosc360-rsvp/client/src/context/AuthContext.jsx
@@ -1,0 +1,30 @@
+import { createContext, useContext, useState } from 'react';
+
+const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+    const [user, setUser ] = useState(()=> {
+        const saved = localStorage.getItem('user');
+        return saved ? JSON.parse(saved) : null;
+    });
+
+    const login = (userData) => {
+        setUser(userData);
+        localStorage.setItem('user', JSON.stringify(userData));
+    };
+
+    const logout = () => {
+        setUser(null);
+        localStorage.removeItem('user');
+    };
+
+
+    return(
+        <AuthContext.Provider value={{user, login, logout}}>
+            { children }
+        </AuthContext.Provider>
+    );
+
+}
+
+export const useAuth = () => useContext(AuthContext);

--- a/cosc360-rsvp/client/src/features/login/LoginCard.jsx
+++ b/cosc360-rsvp/client/src/features/login/LoginCard.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import "./LoginCard.css";
 import { loginApi } from "./api/Login.js";
 import { Link, useNavigate } from "react-router-dom";
+import { useAuth } from "../../context/AuthContext.jsx";
 
 
 
@@ -10,12 +11,14 @@ function LoginCard(){
     const [password, setPassword] = useState("");
     const [message, setMessage] = useState("");
     const navigate = useNavigate();
+    const { login } = useAuth();
 
   async function handleSubmit(e){
     e.preventDefault();
 
     try{
       const data = await loginApi(username, password);
+      login(data);
       setMessage(data.message);
       navigate("/home");
     }catch (error){

--- a/cosc360-rsvp/client/src/features/login/LoginCard.jsx
+++ b/cosc360-rsvp/client/src/features/login/LoginCard.jsx
@@ -18,7 +18,7 @@ function LoginCard(){
 
     try{
       const data = await loginApi(username, password);
-      login(data);
+      login(data.user);
       setMessage(data.message);
       navigate("/home");
     }catch (error){

--- a/cosc360-rsvp/client/src/main.jsx
+++ b/cosc360-rsvp/client/src/main.jsx
@@ -3,13 +3,16 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from "react-router-dom";
 import './css/index.css'
 import App from './app/App.jsx'
+import { AuthProvider } from './context/AuthContext.jsx';
 
 /* Components don't go here! Put them in App.jsx */
 
 createRoot(document.getElementById('root')).render(
   <BrowserRouter>
     <StrictMode>
+    <AuthProvider>
       <App />
+    </AuthProvider>   
     </StrictMode>
   </BrowserRouter>
 )

--- a/cosc360-rsvp/client/src/pages/home.jsx
+++ b/cosc360-rsvp/client/src/pages/home.jsx
@@ -5,6 +5,7 @@ import Sidebar from "../components/sidebar";
 import AdminSidebar from "../components/AdminSidebar";
 import TopNav from "../components/topNav";
 import "../css/Home.css";
+import { useAuth } from "../context/AuthContext.jsx";
 
 const username = "Lexi Loudiadis"
 const isAdmin = false;
@@ -14,6 +15,8 @@ function Homepage() {
     const [events, setEvents] = useState([]);
     const [searchParams] = useSearchParams();
     const navigate = useNavigate();
+    const { user } = useAuth();
+    console.log('Auth user:', user);
 
     const query = searchParams.get("q"); // get the search params sent over from search bar in top nav component
 

--- a/cosc360-rsvp/server/src/modules/controllers/loginController.js
+++ b/cosc360-rsvp/server/src/modules/controllers/loginController.js
@@ -17,7 +17,13 @@ export const processLogin = async (req, res) => {
             return res.status(401).json({ error: "Invalid Credentials" });
         }
 
-        res.json({ success: true, message: "Login Successful" });
+        res.json({ success: true, message: "Login Successful",
+            user: {
+                id: user._id,
+                username: user.username,
+                role: user.role
+            }
+         });
     } catch (err) {
         res.status(500).json({ error: "Something went wrong" });
     }


### PR DESCRIPTION
This PR now implements ProtectedRoutes to all pages except Login, Register, and ResetPassword. To access these pages you need to login.

Auth context: user data is now accessible anywhere within the app via useAuth(). Will require some maintenance on existing pages to implement this app wide but it's now available for use. 

Persistent sessions - login info survives page refreshes by using localStorage. 

User data: backend returns the actual user info (id, username, role) when logged in. 

Logout functionality on Sidebar.jsx implemented as well. 