### PR TITLE
Allows Unregistered Users to Browse Events

### DIFF
--- a/cosc360-rsvp/client/src/app/App.jsx
+++ b/cosc360-rsvp/client/src/app/App.jsx
@@ -22,21 +22,21 @@ function App() {
       <Routes>
 
         {/* Root redirect */}
-        <Route path="/" element={<Navigate to="/login" replace />} />
+        <Route path="/" element={<Navigate to="/home" replace />} />
 
         {/* Public Routes - Unregistered User Pages to Go here too?*/}
         <Route path="/register" element={<RegisterForm />} />
         <Route path="/login" element={<Login />}/>
         <Route path="/reset-password" element={<ResetPassword/>} />
+        <Route path="/home" element={<Homepage />} />
+        <Route path="/event/:id" element={<SingleEventPage />} />
 
 
         {/* Protected Routes - Require Auth to Access*/}
         <Route path="/myevents" element={<ProtectedRoute><MyEvents /></ProtectedRoute>} />
         <Route path="/savedevents" element={<ProtectedRoute><SavedEvents /></ProtectedRoute>} />
-        <Route path="/home" element={<ProtectedRoute><Homepage /></ProtectedRoute>} />
         <Route path="/adminManage" element={<ProtectedRoute><AdminUserManage/></ProtectedRoute>} />
         <Route path="/analytics" element={<ProtectedRoute><Analytics /></ProtectedRoute>} />
-        <Route path="/event/:id" element={<ProtectedRoute><SingleEventPage /></ProtectedRoute>} />
         <Route path="/profile" element={<ProtectedRoute><Profile /></ProtectedRoute>}/>
 
       </Routes> 

--- a/cosc360-rsvp/client/src/app/App.jsx
+++ b/cosc360-rsvp/client/src/app/App.jsx
@@ -22,7 +22,7 @@ function App() {
       <Routes>
 
         {/* Root redirect */}
-        <Route path="/" element={<Navigate to="/home" replace />} />
+        <Route path="/" element={<Navigate to="/login" replace />} />
 
         {/* Public Routes - Unregistered User Pages to Go here too?*/}
         <Route path="/register" element={<RegisterForm />} />

--- a/cosc360-rsvp/client/src/components/LoginOverlay.jsx
+++ b/cosc360-rsvp/client/src/components/LoginOverlay.jsx
@@ -1,0 +1,17 @@
+import LoginCard from "../features/login/LoginCard.jsx";
+import "../css/LoginOverlay.css";
+
+function LoginOverlay({ onClose }){
+    return(
+        <div className="login-overlay-bg" onClick={onClose}>
+            <div onClick={(e)=> e.stopPropagation()}>
+                <LoginCard
+                    onSuccess={onClose}
+                    onClose={onClose}
+                />
+            </div>
+        </div>
+    )
+}
+
+export default LoginOverlay;

--- a/cosc360-rsvp/client/src/components/sidebar.jsx
+++ b/cosc360-rsvp/client/src/components/sidebar.jsx
@@ -1,8 +1,9 @@
-import { Calendar, LogOutIcon, Save, FileBadge } from 'lucide-react';
+import { Calendar, LogOutIcon, Save, FileBadge, LogInIcon } from 'lucide-react';
 import "../css/sidebar.css";
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from "../context/AuthContext.jsx";
 import { useState, useEffect } from 'react';
+import LoginOverlay from "./LoginOverlay.jsx";
 
 const menuItems = [
     { icon: Calendar, label: "Browse Events" },
@@ -23,6 +24,7 @@ const MenuItem = ({ icon: Icon, label, clickItem }) => {
 function Sidebar({ profilePicture }) {
     const navigate = useNavigate();
     const { activeUser, activeUserId, logout } = useAuth();
+    const [showLogin, setShowLogin] = useState(false);
     const fullName = activeUser ? `${activeUser.firstName} ${activeUser.lastName}` : '';
 
     const [photo, setPhoto] = useState(null);
@@ -51,6 +53,8 @@ function Sidebar({ profilePicture }) {
     function handleSidebarClick(index) {
         if (index === 0) {
             navigate(`/home`);
+        }else if(!activeUser) {
+            setShowLogin(true); 
         } else if (index === 1) {
             navigate(`/savedevents`);
         } else if (index === 2) {
@@ -60,6 +64,8 @@ function Sidebar({ profilePicture }) {
 
 
     return (
+        <>
+        {showLogin && <LoginOverlay onClose={() => setShowLogin(false)}/>}
         <div className="sidebar">
             <div className="menu-container">
                 <div className='profile-section'>
@@ -75,8 +81,14 @@ function Sidebar({ profilePicture }) {
                         )}
                     </div>
                     <div className="sidebar-header">
+                       {activeUser ? ( 
+                        <>
                         <h4>{fullName}</h4>
                         <p className="view-profile" onClick={() => navigate('/profile')}>View Profile</p>
+                        </>
+                        ) : (
+                            <h4>Guest</h4>    
+                     )}
                     </div>
                 </div>
             </div>
@@ -90,13 +102,14 @@ function Sidebar({ profilePicture }) {
                 ))}
             </div>
             <div className="logout">
-                <MenuItem
-                    icon={LogOutIcon}
-                    label="Logout"
-                    clickItem={handleLogout} />
+                {activeUser ?(
+                    <MenuItem icon={LogOutIcon} label="Logout" clickItem={handleLogout} />
+                ) :(
+                    <MenuItem icon = {LogInIcon} label="Login" clickItem={() => setShowLogin(true)}/>
+                )}
             </div>
         </div>
-
+        </>
     )
 };
 

--- a/cosc360-rsvp/client/src/components/topNav.jsx
+++ b/cosc360-rsvp/client/src/components/topNav.jsx
@@ -3,6 +3,8 @@ import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import '../css/topNav.css'
 import { Plus, Search } from 'lucide-react';
 import CreateEventForm from '../features/event/createEvent/CreateEventForm';
+import { useAuth } from "../context/AuthContext.jsx";
+import LoginOverlay from "./LoginOverlay.jsx";
 
 function Searchbar( { value, onClick, onChange }) {
      return (
@@ -32,6 +34,8 @@ function TopNav () {
     const navigate = useNavigate();
     const location = useLocation();
     const [searchParams] = useSearchParams();
+    const { activeUser } = useAuth();
+    const [showLogin, setShowLogin] = useState(false);
 
     useEffect(() => {
         setSearchQuery(searchParams.get("q") || "");
@@ -71,6 +75,7 @@ function TopNav () {
 
     return (
         <>
+            {showLogin && <LoginOverlay onClose={() => setShowLogin(false)}/>}
             <div className='top-nav'>
                 <Searchbar
                     onClick={handleSearch}
@@ -81,7 +86,13 @@ function TopNav () {
                         updateSearch(nextValue);
                     }}
                 />
-                <AddEventButton onClick={() => setShowCreateForm(true)} />
+                <AddEventButton onClick={() => {
+                    if(!activeUser){
+                        setShowLogin(true);
+                    }else{
+                    setShowCreateForm(true);
+                    }
+                    }} />
             </div>
             {showCreateForm && (
                 <CreateEventForm onClose={() => setShowCreateForm(false)} />

--- a/cosc360-rsvp/client/src/css/LoginOverlay.css
+++ b/cosc360-rsvp/client/src/css/LoginOverlay.css
@@ -1,0 +1,17 @@
+.login-overlay-bg{
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.login-overlay-bg .auth-background{
+    background:none;
+    background-image:none;
+    padding:0;
+    min-height: unset;
+    min-width:unset;
+}

--- a/cosc360-rsvp/client/src/features/login/LoginCard.css
+++ b/cosc360-rsvp/client/src/features/login/LoginCard.css
@@ -10,6 +10,7 @@
         justify-content: center;
         flex-direction: column;
         height: 40vh;
+        position: relative;
 }
 
 .title{
@@ -108,4 +109,14 @@
 a{
     font-size:16px;
     text-align:center;
+}
+
+.login-card-close{
+    position: absolute;
+    top: 12px;
+    right: 14px;
+    width: 24px;
+    height: 24px;
+    cursor: pointer;
+    color:white;
 }

--- a/cosc360-rsvp/client/src/features/login/LoginCard.css
+++ b/cosc360-rsvp/client/src/features/login/LoginCard.css
@@ -32,6 +32,7 @@
     border: 0.5px solid #ccc;
     border-radius:12px;
     box-shadow: 0 4px 20px(0,0,0,0.1);
+    position: relative;
 }
 
 .textField{
@@ -89,6 +90,7 @@
 #forgotPassword{
     font-size: 0.5rem;
     align-self:center;
+    color:#60A5FA;
 }
 
 #forgotPassword:hover{
@@ -99,6 +101,7 @@
 #createAccount{
     font-size: 0.5rem;
     align-self:center;
+    color:#60A5FA;
 }
 
 #createAccount:hover{
@@ -118,5 +121,20 @@ a{
     width: 24px;
     height: 24px;
     cursor: pointer;
-    color:white;
+    color:#60A5FA;
+}
+
+.guest-link{
+    background: none;
+    border: none;
+    color: #60A5FA;
+    font-size: 16px;
+    text-align: center;
+    cursor: pointer;
+    padding:0;
+}
+
+.guest-link:hover{
+    background: none;
+    border:none;
 }

--- a/cosc360-rsvp/client/src/features/login/LoginCard.jsx
+++ b/cosc360-rsvp/client/src/features/login/LoginCard.jsx
@@ -56,6 +56,7 @@ function LoginCard({ onSuccess, onClose }) {
           <button id="login-btn" type="submit">Login</button>
           <Link to="/reset-password" id="forgotPassword">Forgot Password?</Link>
           <Link to="/register">Create Account</Link>
+          <Link to="/home">Continue as Guest</Link>
 
           <p>{message}</p>
         </form>

--- a/cosc360-rsvp/client/src/features/login/LoginCard.jsx
+++ b/cosc360-rsvp/client/src/features/login/LoginCard.jsx
@@ -36,10 +36,11 @@ function LoginCard({ onSuccess, onClose }) {
   return (
     <div className="auth-background">
       <div className="login-container">
+      
+        <form id="login" onSubmit={handleSubmit}>
         {onClose && (
           <XCircle className="login-card-close" onClick={onClose}/>
         )}
-        <form id="login" onSubmit={handleSubmit}>
           <h2 className="title">Welcome Back!</h2>
           <input className="textField"
             type="text"
@@ -56,8 +57,12 @@ function LoginCard({ onSuccess, onClose }) {
           <button id="login-btn" type="submit">Login</button>
           <Link to="/reset-password" id="forgotPassword">Forgot Password?</Link>
           <Link to="/register">Create Account</Link>
+          
+          {onClose ? (
+            <button type="button" className="guest-link" onClick={onClose}>Continue as Guest</button>
+          ) : (
           <Link to="/home">Continue as Guest</Link>
-
+          )}
           <p>{message}</p>
         </form>
 

--- a/cosc360-rsvp/client/src/features/login/LoginCard.jsx
+++ b/cosc360-rsvp/client/src/features/login/LoginCard.jsx
@@ -3,10 +3,11 @@ import "./LoginCard.css";
 import { loginApi } from "./api/Login.js";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "../../context/AuthContext.jsx";
+import { XCircle } from "lucide-react";
 
 
 
-function LoginCard() {
+function LoginCard({ onSuccess, onClose }) {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [message, setMessage] = useState("");
@@ -21,7 +22,11 @@ function LoginCard() {
       login(data.user);
       setMessage(data.message);
 
-      navigate("/home");
+      if (onSuccess){
+        onSuccess();
+      } else {
+        navigate("/home");
+      }
     } catch (error) {
       setMessage(error.message);
     }
@@ -31,7 +36,9 @@ function LoginCard() {
   return (
     <div className="auth-background">
       <div className="login-container">
-
+        {onClose && (
+          <XCircle className="login-card-close" onClick={onClose}/>
+        )}
         <form id="login" onSubmit={handleSubmit}>
           <h2 className="title">Welcome Back!</h2>
           <input className="textField"

--- a/cosc360-rsvp/client/src/features/register/RegisterForm.jsx
+++ b/cosc360-rsvp/client/src/features/register/RegisterForm.jsx
@@ -100,6 +100,8 @@ function RegisterForm(){
                 <div>
                     <p>Already Have an Account?</p>
                     <Link to="/login">Login</Link>
+                    <br></br>
+                    <Link to="/home">Continue as Guest</Link>
                 </div>    
             </form>
 

--- a/cosc360-rsvp/client/src/pages/event.jsx
+++ b/cosc360-rsvp/client/src/pages/event.jsx
@@ -18,7 +18,6 @@ function EventPage() {
     const [editingEvent, setEditingEvent] = useState(null);
     const [rsvpStatus, setRsvpStatus] = useState("");
     const { activeUser, activeUserId } = useAuth();
-    const { user } = useAuth();
     const [showLogin, setShowLogin] = useState(false);
     
     const userCreated = function () {
@@ -101,6 +100,9 @@ function EventPage() {
     async function handleReviewClick() {
         if (canReview) {
             setReviewingEvent(event);
+        } else if (!activeUser) {
+            setShowLogin(true);
+            return;
         } else if (hasReviewed()) {
             alert("You have already reviewed this event!")
         } else if (rsvpStatus === 'no' || rsvpStatus === 'saved') {
@@ -123,7 +125,6 @@ function EventPage() {
         }
 
         // Use logged in user id when available and keep demo fallback for local testing.
-        const userId = localStorage.getItem("userId") || "000000000000000000000001";
         if (!activeUserId) {
             alert("Please log in to RSVP.");
             return;
@@ -161,7 +162,7 @@ function EventPage() {
             const result = await response.json();
 
             if (!response.ok) {
-                alert(`Something went wrong: ${result.error}`);
+                alert(result.error);
                 return;
             }
 

--- a/cosc360-rsvp/client/src/pages/event.jsx
+++ b/cosc360-rsvp/client/src/pages/event.jsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from "react";
 import { useAuth } from "../context/AuthContext.jsx";
 import ReviewModal from "../features/event/reviews/ReviewModal.jsx";
 import CreateEventForm from "../features/event/createEvent/CreateEventForm.jsx";
+import LoginOverlay from "../components/LoginOverlay.jsx";
 
 function EventPage() {
     const { id } = useParams();
@@ -18,6 +19,7 @@ function EventPage() {
     const [rsvpStatus, setRsvpStatus] = useState("");
     const { activeUser, activeUserId } = useAuth();
     const { user } = useAuth();
+    const [showLogin, setShowLogin] = useState(false);
     
     const userCreated = function () {
         if (!activeUser || !activeUserId || !event) return false;
@@ -109,6 +111,12 @@ function EventPage() {
     }
 
     async function handleRsvpClick() {
+        
+        if(!activeUser){
+            setShowLogin(true);
+            return;
+        }
+        
         if (!eventIsUpcoming) {
             alert("The event has passed. You can no longer RSVP.");
             return;
@@ -192,6 +200,7 @@ function EventPage() {
     if (!event) {
         return (
             <div className="homepage-layout">
+                {showLogin && <LoginOverlay onClose={() => setShowLogin(false)}/>}
                 <Sidebar />
                 <div className="main-content">
                     <TopNav />
@@ -205,6 +214,7 @@ function EventPage() {
 
     return (
         <div className="homepage-layout">
+            {showLogin && <LoginOverlay onClose={() => setShowLogin(false)}/>}
             <Sidebar />
             <div className="main-content">
                 <TopNav />


### PR DESCRIPTION
This PR adds support for unregistered users to browse events. Protected actions (RSVP, create event, saved events, my events) now trigger a login overlay instead of completely redirecting to the login page. 

/home and /event:id are no longer protected routes in App.jsx.

Added Continue as Guest on the overlay as well as on the register form and login page. The app continues to build and direct to login page. If the unregistered user needs to create an account they'll just be redirected to the Register Page but can go back to browse by clicking "Continue as Guest".