### PR TITLE
Admin delete event, auto reload on create event

### DIFF
--- a/cosc360-rsvp/client/src/components/topNav.jsx
+++ b/cosc360-rsvp/client/src/components/topNav.jsx
@@ -6,20 +6,20 @@ import CreateEventForm from '../features/event/createEvent/CreateEventForm';
 import { useAuth } from "../context/AuthContext.jsx";
 import LoginOverlay from "./LoginOverlay.jsx";
 
-function Searchbar( { value, onClick, onChange }) {
-     return (
+function Searchbar({ value, onClick, onChange }) {
+    return (
         <div className='search-container'>
             <input type='text' id='top-searchbar' placeholder='Search for an event ...' value={value} onChange={onChange} />
-            <Search size={18} color='gray' className='search-icon' onClick={onClick}/>
+            <Search size={18} color='gray' className='search-icon' onClick={onClick} />
         </div>
     );
 }
 
-function AddEventButton ({ onClick }) {
+function AddEventButton({ onClick }) {
     return (
         <div className='add-event-btn' onClick={onClick}>
             <div className='add-event-icon'>
-                <Plus size= {18} />
+                <Plus size={18} />
                 <p>Create Event</p>
             </div>
         </div>
@@ -28,7 +28,7 @@ function AddEventButton ({ onClick }) {
 
 
 
-function TopNav () {
+function TopNav() {
     const [showCreateForm, setShowCreateForm] = useState(false);
     const [searchQuery, setSearchQuery] = useState("");
     const navigate = useNavigate();
@@ -73,9 +73,24 @@ function TopNav () {
         updateSearch(searchQuery);
     }
 
+    function handleCreateEventClose(createdEvent) {
+        setShowCreateForm(false);
+
+        // Refresh the current view after successful creation so new events appear immediately.
+        if (!createdEvent) return;
+
+        const createdEventId = createdEvent?._id || createdEvent?.id;
+        if (location.pathname.startsWith("/event/") && createdEventId) {
+            navigate(`/event/${createdEventId}`);
+            return;
+        }
+
+        navigate(0);
+    }
+
     return (
         <>
-            {showLogin && <LoginOverlay onClose={() => setShowLogin(false)}/>}
+            {showLogin && <LoginOverlay onClose={() => setShowLogin(false)} />}
             <div className='top-nav'>
                 <Searchbar
                     onClick={handleSearch}
@@ -87,15 +102,15 @@ function TopNav () {
                     }}
                 />
                 <AddEventButton onClick={() => {
-                    if(!activeUser){
+                    if (!activeUser) {
                         setShowLogin(true);
-                    }else{
-                    setShowCreateForm(true);
+                    } else {
+                        setShowCreateForm(true);
                     }
-                    }} />
+                }} />
             </div>
             {showCreateForm && (
-                <CreateEventForm onClose={() => setShowCreateForm(false)} />
+                <CreateEventForm onClose={handleCreateEventClose} />
             )}
         </>
     );

--- a/cosc360-rsvp/client/src/features/adminManagement/AdminManagement.jsx
+++ b/cosc360-rsvp/client/src/features/adminManagement/AdminManagement.jsx
@@ -9,7 +9,7 @@ const AdminManagement = () => {
     const [userSearch, setUserSearch] = useState('');
     const [eventSearch, setEventSearch] = useState('');
     const [editingEvent, setEditingEvent] = useState(null);
-    const { activeUserId, logout } = useAuth();
+    const { activeUser, activeUserId } = useAuth();
 
     useEffect(() => {
         if (!activeUserId) {
@@ -36,46 +36,73 @@ const AdminManagement = () => {
         fetchData();
     }, [activeUserId]);
 
-    async function handleDeleteUser(userId){
-        if(!confirm("Are you sure you want to delete this user?")) return;
-        try{
+    async function handleDeleteUser(userId) {
+        if (!confirm("Are you sure you want to delete this user?")) return;
+        try {
             const response = await fetch(`/api/users/${userId}`, {
                 method: 'DELETE',
-                headers: {'x-user-id': activeUserId},
+                headers: { 'x-user-id': activeUserId },
             });
-            if(!response.ok){
+            if (!response.ok) {
                 const result = await response.json();
                 alert(`Error: ${result.error}`);
                 return;
             }
             setUsers(prev => prev.filter(u => u._id !== userId));
-        }catch (err){
+        } catch (err) {
             console.log('Error deleting user:', err);
         }
     }
 
-    async function handlePromoteUser(userId, currentRole){
+    async function handlePromoteUser(userId, currentRole) {
         const newRole = currentRole === 'admin' ? 'user' : 'admin';
         const message = newRole === 'admin' ? "Promote this user to admin?" : "Demote this user to regular user?";
-        if(!confirm(message)) return;
-        try{
-            const response = await fetch(`/api/users/${userId}/role`,{
+        if (!confirm(message)) return;
+        try {
+            const response = await fetch(`/api/users/${userId}/role`, {
                 method: 'PUT',
-                headers:{
+                headers: {
                     'Content-Type': 'application/json',
-                    'x-user-id': activeUserId,  
+                    'x-user-id': activeUserId,
                 },
-                body: JSON.stringify({ role: newRole}),
+                body: JSON.stringify({ role: newRole }),
             });
-            if(!response.ok){
+            if (!response.ok) {
                 const result = await response.json();
                 alert(`Error: ${result.error}`);
                 return;
             }
-            setUsers(prev => prev.map(u => u._id === userId ? { ...u, role: newRole} : u ));
+            setUsers(prev => prev.map(u => u._id === userId ? { ...u, role: newRole } : u));
 
-        }catch (err){
+        } catch (err) {
             console.log('Error promoting user:', err);
+        }
+    }
+
+    async function handleDeleteEvent(eventId) {
+        if (!activeUserId || activeUser?.role !== 'admin') {
+            alert("Only admins can delete events.");
+            return;
+        }
+
+        if (!confirm("Are you sure you want to delete this event?")) return;
+
+        try {
+            const response = await fetch(`/api/events/${eventId}`, {
+                method: 'DELETE',
+                headers: { 'x-user-id': activeUserId },
+            });
+
+            const result = await response.json();
+
+            if (!response.ok) {
+                alert(`Error: ${result.error}`);
+                return;
+            }
+
+            setEvents(prev => prev.filter(e => e._id !== eventId));
+        } catch (err) {
+            console.log('Error deleting event:', err);
         }
     }
 
@@ -110,15 +137,15 @@ const AdminManagement = () => {
                     {filteredUsers.map((u) => (
                         <div className="list-item" key={u._id}>
                             <span>{u.firstName} {u.lastName} | {u.username} | {u.role}</span>
-                            <div className = "event-actions">
-                                
-                                    <button className="settings-btn" onClick={() => handlePromoteUser(u._id, u.role)} 
+                            <div className="event-actions">
+
+                                <button className="settings-btn" onClick={() => handlePromoteUser(u._id, u.role)}
                                     title={u.role === 'admin' ? "Demote to user" : "Promote to admin"}>
-                                        <ShieldCheck size={18} color={u.role === 'admin' ? "green" : "navy"}/>
-                                    </button>
-                                
+                                    <ShieldCheck size={18} color={u.role === 'admin' ? "green" : "navy"} />
+                                </button>
+
                                 <button className="settings-btn" onClick={() => handleDeleteUser(u._id)} title="Delete user">
-                                    <Trash2 size={18} color="red"/>
+                                    <Trash2 size={18} color="red" />
                                 </button>
                             </div>
                         </div>
@@ -141,6 +168,9 @@ const AdminManagement = () => {
                             <div className="event-actions">
                                 <button className="settings-btn" onClick={() => setEditingEvent(event)}>
                                     <Pencil size={18} color="navy" />
+                                </button>
+                                <button className="settings-btn" onClick={() => handleDeleteEvent(event._id)} title="Delete event">
+                                    <Trash2 size={18} color="red" />
                                 </button>
                             </div>
                         </div>

--- a/cosc360-rsvp/client/src/pages/event.jsx
+++ b/cosc360-rsvp/client/src/pages/event.jsx
@@ -45,6 +45,10 @@ function EventPage() {
             return;
         }
 
+        if (!confirm("Are you sure you want to delete this event?")) {
+            return;
+        }
+
         try {
             const response = await fetch(`/api/events/${id}`, {
                 method: "DELETE",

--- a/cosc360-rsvp/client/src/pages/event.jsx
+++ b/cosc360-rsvp/client/src/pages/event.jsx
@@ -4,7 +4,7 @@ import TopNav from "../components/topNav";
 import Sidebar from "../components/sidebar";
 import "../css/Home.css";
 import "../css/Event.css";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { useAuth } from "../context/AuthContext.jsx";
 import ReviewModal from "../features/event/reviews/ReviewModal.jsx";
@@ -14,6 +14,7 @@ import AdminSidebar from "../components/AdminSidebar.jsx";
 
 function EventPage() {
     const { id } = useParams();
+    const navigate = useNavigate();
     const [event, setEvent] = useState(null);
     const [reviewingEvent, setReviewingEvent] = useState(null);
     const [editingEvent, setEditingEvent] = useState(null);
@@ -59,7 +60,8 @@ function EventPage() {
                 return;
             }
 
-            alert("Deleted event successfully.")
+            alert("Deleted event successfully.");
+            navigate("/home");
         } catch (error) {
             console.log("Error deleting event: ", error);
         }

--- a/cosc360-rsvp/client/src/pages/event.jsx
+++ b/cosc360-rsvp/client/src/pages/event.jsx
@@ -20,8 +20,8 @@ function EventPage() {
     const [rsvpStatus, setRsvpStatus] = useState("");
     const { activeUser, activeUserId } = useAuth();
     const [showLogin, setShowLogin] = useState(false);
-    
-    
+
+
     const userCreated = function () {
         if (!activeUser || !activeUserId || !event) return false;
         const creatorId = event.createdBy?._id?.toString() || event.createdBy?.toString();
@@ -31,12 +31,25 @@ function EventPage() {
     const eventIsUpcoming = event ? isUpcoming(event.date, event.endTime) : false;
     const canReview = (event !== null && rsvpStatus === 'yes' && !eventIsUpcoming && !hasReviewed());
     const canRsvp = (event !== null && rsvpStatus !== 'yes' && eventIsUpcoming)
-  
+
 
     async function handleDeleteEventClick() {
+        if (!activeUser || !activeUserId) {
+            alert("Please log in to delete this event.");
+            return;
+        }
+
+        if (!userCreated()) {
+            alert("You are not allowed to delete this event.");
+            return;
+        }
+
         try {
             const response = await fetch(`/api/events/${id}`, {
-                method: "DELETE"
+                method: "DELETE",
+                headers: {
+                    "x-user-id": activeUserId,
+                },
             });
 
             const result = await response.json();
@@ -63,7 +76,7 @@ function EventPage() {
         }
         return false;
     }
-    
+
 
     function isUpcoming(eventDate, endTime) {
         const [hours, minutes] = endTime.split(':');
@@ -115,12 +128,12 @@ function EventPage() {
     }
 
     async function handleRsvpClick() {
-        
-        if(!activeUser){
+
+        if (!activeUser) {
             setShowLogin(true);
             return;
         }
-        
+
         if (!eventIsUpcoming) {
             alert("The event has passed. You can no longer RSVP.");
             return;
@@ -203,8 +216,8 @@ function EventPage() {
     if (!event) {
         return (
             <div className="homepage-layout">
-                {showLogin && <LoginOverlay onClose={() => setShowLogin(false)}/>}
-                <Sidebar />
+                {showLogin && <LoginOverlay onClose={() => setShowLogin(false)} />}
+                {activeUser?.role === 'admin' ? (<AdminSidebar />) : (<Sidebar />)}
                 <div className="main-content">
                     <TopNav />
                     <div className="main-content-area">
@@ -217,8 +230,7 @@ function EventPage() {
 
     return (
         <div className="homepage-layout">
-            {showLogin && <LoginOverlay onClose={() => setShowLogin(false)}/>}
-            <Sidebar />
+            {showLogin && <LoginOverlay onClose={() => setShowLogin(false)} />}
             {activeUser?.role === 'admin' ? (<AdminSidebar />) : (<Sidebar />)}
             <div className="main-content">
                 <TopNav />

--- a/cosc360-rsvp/client/src/tests/EventPage.frontend.test.jsx
+++ b/cosc360-rsvp/client/src/tests/EventPage.frontend.test.jsx
@@ -34,6 +34,7 @@ describe("EventPage frontend tests", () => {
         jest.clearAllMocks();
         global.fetch = jest.fn();
         global.alert = jest.fn();
+        global.confirm = jest.fn().mockReturnValue(true);
         useParams.mockReturnValue({ id: "event_1" });
         useNavigate.mockReturnValue(mockNavigate);
     });
@@ -215,6 +216,8 @@ describe("EventPage frontend tests", () => {
         const deleteButton = await screen.findByText("Delete Event");
         fireEvent.click(deleteButton);
 
+        expect(global.confirm).toHaveBeenCalledWith("Are you sure you want to delete this event?");
+
         expect(global.fetch).toHaveBeenCalledWith("/api/events/event_1", {
             method: "DELETE",
             headers: { "x-user-id": "owner_1" },
@@ -223,5 +226,45 @@ describe("EventPage frontend tests", () => {
             expect(global.alert).toHaveBeenCalledWith("Deleted event successfully.");
         });
         expect(mockNavigate).toHaveBeenCalledWith("/home");
+    });
+
+    test("does not delete when user cancels confirmation", async () => {
+        useAuth.mockReturnValue({
+            activeUser: { role: "user" },
+            activeUserId: "owner_1",
+            user: { id: "owner_1" },
+        });
+
+        global.confirm.mockReturnValue(false);
+
+        global.fetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => [{ status: "yes" }],
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    _id: "event_1",
+                    name: "Owner Delete Event",
+                    createdBy: { _id: "owner_1" },
+                    date: "2030-06-15T00:00:00.000Z",
+                    endTime: "20:00",
+                    price: 10,
+                    description: "Event description",
+                    reviews: [],
+                }),
+            });
+
+        render(<EventPage />);
+
+        const deleteButton = await screen.findByText("Delete Event");
+        fireEvent.click(deleteButton);
+
+        expect(global.confirm).toHaveBeenCalledWith("Are you sure you want to delete this event?");
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+        expect(global.fetch).not.toHaveBeenCalledWith("/api/events/event_1", expect.anything());
+        expect(global.alert).not.toHaveBeenCalledWith("Deleted event successfully.");
+        expect(mockNavigate).not.toHaveBeenCalled();
     });
 });

--- a/cosc360-rsvp/client/src/tests/EventPage.frontend.test.jsx
+++ b/cosc360-rsvp/client/src/tests/EventPage.frontend.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import EventPage from "../pages/event.jsx";
 import { useParams } from "react-router-dom";
 import { useAuth } from "../context/AuthContext.jsx";
@@ -173,5 +173,50 @@ describe("EventPage frontend tests", () => {
         const editButton = await screen.findByText("Edit Event");
         fireEvent.click(editButton);
         expect(screen.getByText("CreateEventForm")).toBeInTheDocument();
+    });
+
+    // tests delete action, owner delete should include authenticated user header
+    test("sends authenticated delete request when owner clicks delete", async () => {
+        useAuth.mockReturnValue({
+            activeUser: { role: "user" },
+            activeUserId: "owner_1",
+            user: { id: "owner_1" },
+        });
+
+        global.fetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => [{ status: "yes" }],
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    _id: "event_1",
+                    name: "Owner Delete Event",
+                    createdBy: { _id: "owner_1" },
+                    date: "2030-06-15T00:00:00.000Z",
+                    endTime: "20:00",
+                    price: 10,
+                    description: "Event description",
+                    reviews: [],
+                }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ message: "Event deleted successfully!" }),
+            });
+
+        render(<EventPage />);
+
+        const deleteButton = await screen.findByText("Delete Event");
+        fireEvent.click(deleteButton);
+
+        expect(global.fetch).toHaveBeenCalledWith("/api/events/event_1", {
+            method: "DELETE",
+            headers: { "x-user-id": "owner_1" },
+        });
+        await waitFor(() => {
+            expect(global.alert).toHaveBeenCalledWith("Deleted event successfully.");
+        });
     });
 });

--- a/cosc360-rsvp/client/src/tests/EventPage.frontend.test.jsx
+++ b/cosc360-rsvp/client/src/tests/EventPage.frontend.test.jsx
@@ -1,10 +1,11 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import EventPage from "../pages/event.jsx";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useAuth } from "../context/AuthContext.jsx";
 
 jest.mock("react-router-dom", () => ({
     useParams: jest.fn(),
+    useNavigate: jest.fn(),
 }));
 
 jest.mock("../context/AuthContext.jsx", () => ({
@@ -27,11 +28,14 @@ jest.mock("../features/event/reviews/ReviewCard", () => () => <div>ReviewCard</d
 jest.mock("../features/event/createEvent/CreateEventForm.jsx", () => () => <div>CreateEventForm</div>);
 
 describe("EventPage frontend tests", () => {
+    const mockNavigate = jest.fn();
+
     beforeEach(() => {
         jest.clearAllMocks();
         global.fetch = jest.fn();
         global.alert = jest.fn();
         useParams.mockReturnValue({ id: "event_1" });
+        useNavigate.mockReturnValue(mockNavigate);
     });
 
     // tests loading path first, then event details render after fetch resolves
@@ -218,5 +222,6 @@ describe("EventPage frontend tests", () => {
         await waitFor(() => {
             expect(global.alert).toHaveBeenCalledWith("Deleted event successfully.");
         });
+        expect(mockNavigate).toHaveBeenCalledWith("/home");
     });
 });

--- a/cosc360-rsvp/server/src/modules/controllers/eventController.js
+++ b/cosc360-rsvp/server/src/modules/controllers/eventController.js
@@ -52,7 +52,7 @@ export const createReview = async (req, res) => {
     try {
         const eventId = req.params.id;
         const userId = req.userId;
-        const data = {...req.body};
+        const data = { ...req.body };
 
         const newReview = await eventService.createReview(data, eventId, userId);
 
@@ -70,7 +70,7 @@ export const createReview = async (req, res) => {
         }
 
         if (error.message === "You have already reviewed this event!") {
-            return res.status(400).json( {error: error.message})
+            return res.status(400).json({ error: error.message })
         }
 
         console.log("Error creating review:", error);
@@ -100,7 +100,7 @@ export const updateEvent = async (req, res) => {
 
 export const deleteEvent = async (req, res) => {
     try {
-        const deletedEvent = await eventService.deleteEvent(req.params.id);
+        const deletedEvent = await eventService.deleteEvent(req.params.id, req.userId, req.userRole);
 
         if (!deletedEvent) {
             return res.status(404).json({ error: "Event not found" });
@@ -108,6 +108,9 @@ export const deleteEvent = async (req, res) => {
 
         res.json({ message: "Event deleted successfully!", event: deletedEvent });
     } catch (error) {
+        if (error.message === "Forbidden") {
+            return res.status(403).json({ error: "You are not allowed to delete this event" });
+        }
         console.log("Error deleting event: ", error);
         res.status(500).json({ error: "Could not delete event" });
 

--- a/cosc360-rsvp/server/src/modules/routes/eventRoutes.js
+++ b/cosc360-rsvp/server/src/modules/routes/eventRoutes.js
@@ -10,6 +10,6 @@ router.post("/", authMiddleware, uploadImage.single("image"), eventController.cr
 router.post("/review/:id", authMiddleware, eventController.createReview);
 router.get("/:id", eventController.getEventById);
 router.put("/:id", authMiddleware, uploadImage.single("image"), eventController.updateEvent);
-router.delete("/:id", eventController.deleteEvent);
+router.delete("/:id", authMiddleware, eventController.deleteEvent);
 
 export default router;

--- a/cosc360-rsvp/server/src/modules/services/eventServices.js
+++ b/cosc360-rsvp/server/src/modules/services/eventServices.js
@@ -26,7 +26,17 @@ export async function getEventById(id) {
     return await eventRepository.findEvent(id);
 }
 
-export async function deleteEvent(id) {
+export async function deleteEvent(id, userId, userRole) {
+    const event = await eventRepository.findEvent(id);
+    if (!event) return null;
+
+    const creatorId = event.createdBy?._id?.toString() || event.createdBy?.toString();
+    const isAdmin = userRole === "admin";
+
+    if (!isAdmin && creatorId !== userId?.toString()) {
+        throw new Error("Forbidden");
+    }
+
     return await eventRepository.deleteEvent(id);
 }
 

--- a/cosc360-rsvp/server/src/tests/event.test.js
+++ b/cosc360-rsvp/server/src/tests/event.test.js
@@ -274,13 +274,26 @@ describe("Events", () => {
     });
 
     describe("DELETE /api/events/:id", () => {
-        // tests delete happy path, event is removed and no longer retrievable
-        test("deletes an event successfully", async () => {
-            const user = await createUser({ username: "event_delete_host" });
+        // tests delete auth guard, should reject requests without user header
+        test("returns 401 when deleting without auth header", async () => {
+            const user = await createUser({ username: "event_delete_noauth_host" });
+            const createRes = await createEventThroughApi(user._id, { name: "Needs Delete Auth" });
+
+            const res = await request(app).delete(`/api/events/${createRes.body.event._id}`);
+
+            expect(res.statusCode).toBe(401);
+            expect(res.body.error).toBe("Missing user ID header");
+        });
+
+        // tests owner delete happy path, event is removed and no longer retrievable
+        test("deletes an event successfully for owner", async () => {
+            const user = await createUser({ username: "event_delete_owner" });
             const createRes = await createEventThroughApi(user._id, { name: "Delete Me" });
             const eventId = createRes.body.event._id;
 
-            const deleteRes = await request(app).delete(`/api/events/${eventId}`);
+            const deleteRes = await request(app)
+                .delete(`/api/events/${eventId}`)
+                .set("x-user-id", user._id.toString());
 
             expect(deleteRes.statusCode).toBe(200);
             expect(deleteRes.body.message).toBe("Event deleted successfully!");
@@ -290,11 +303,42 @@ describe("Events", () => {
             expect(fetchRes.statusCode).toBe(404);
         });
 
+        // tests admin override path, admin can delete events created by other users
+        test("allows admin to delete another user's event", async () => {
+            const host = await createUser({ username: "event_delete_admin_host" });
+            const admin = await createUser({ username: "event_delete_admin", role: "admin" });
+            const createRes = await createEventThroughApi(host._id, { name: "Delete By Admin" });
+
+            const res = await request(app)
+                .delete(`/api/events/${createRes.body.event._id}`)
+                .set("x-user-id", admin._id.toString());
+
+            expect(res.statusCode).toBe(200);
+            expect(res.body.message).toBe("Event deleted successfully!");
+        });
+
+        // tests permission guard, non-owner non-admin cannot delete events
+        test("returns 403 when non-owner non-admin tries to delete", async () => {
+            const host = await createUser({ username: "event_delete_host_forbidden" });
+            const stranger = await createUser({ username: "event_delete_stranger" });
+            const createRes = await createEventThroughApi(host._id, { name: "Cannot Delete" });
+
+            const res = await request(app)
+                .delete(`/api/events/${createRes.body.event._id}`)
+                .set("x-user-id", stranger._id.toString());
+
+            expect(res.statusCode).toBe(403);
+            expect(res.body.error).toBe("You are not allowed to delete this event");
+        });
+
         // delete should return 404 when the event does not exist
         test("returns 404 when deleting a missing event", async () => {
+            const user = await createUser({ username: "event_delete_missing" });
             const missingId = "507f1f77bcf86cd799439011";
 
-            const res = await request(app).delete(`/api/events/${missingId}`);
+            const res = await request(app)
+                .delete(`/api/events/${missingId}`)
+                .set("x-user-id", user._id.toString());
 
             expect(res.statusCode).toBe(404);
             expect(res.body.error).toBe("Event not found");

--- a/cosc360-rsvp/server/src/tests/eventServices.unit.test.js
+++ b/cosc360-rsvp/server/src/tests/eventServices.unit.test.js
@@ -90,6 +90,42 @@ describe("eventServices unit tests", () => {
         expect(mockEventRepository.updateEvent).not.toHaveBeenCalled();
     });
 
+    // tests delete missing path, service returns null when event is absent
+    test("deleteEvent returns null when event does not exist", async () => {
+        mockEventRepository.findEvent.mockResolvedValue(null);
+
+        const result = await eventServices.deleteEvent("missing_id", "user_1", "user");
+
+        expect(result).toBeNull();
+        expect(mockEventRepository.deleteEvent).not.toHaveBeenCalled();
+    });
+
+    // tests delete permission path, non-admin non-owner should get forbidden error
+    test("deleteEvent throws Forbidden for non-owner non-admin", async () => {
+        mockEventRepository.findEvent.mockResolvedValue({
+            createdBy: { _id: { toString: () => "owner_1" } },
+        });
+
+        await expect(
+            eventServices.deleteEvent("event_1", "different_user", "user")
+        ).rejects.toThrow("Forbidden");
+
+        expect(mockEventRepository.deleteEvent).not.toHaveBeenCalled();
+    });
+
+    // tests delete admin override path, admin can delete someone else's event
+    test("deleteEvent allows admin to delete another user's event", async () => {
+        mockEventRepository.findEvent.mockResolvedValue({
+            createdBy: { _id: { toString: () => "owner_1" } },
+        });
+        mockEventRepository.deleteEvent.mockResolvedValue({ _id: "event_1" });
+
+        const result = await eventServices.deleteEvent("event_1", "admin_1", "admin");
+
+        expect(mockEventRepository.deleteEvent).toHaveBeenCalledWith("event_1");
+        expect(result).toEqual({ _id: "event_1" });
+    });
+
     // tests permission path, non-admin non-owner should get forbidden error
     test("updateEvent throws Forbidden for non-owner non-admin", async () => {
         mockEventRepository.findEvent.mockResolvedValue({


### PR DESCRIPTION
- Added confirmation dialog when deleting an event (admin and user).
- Redirected to the browse events page after event deletion.
- Fixed duplicate sidebar issue on the event detail page.
- Made event list auto-refresh after adding a new event (no manual reload needed).
- Updated UI to ensure new events appear immediately after creation.
- Ran, created and passed all relevant frontend tests to validate changes.