### PR TITLE
Finished saved events tests and behavior fixes

### DIFF
--- a/cosc360-rsvp/client/src/features/event/homepageEvents/EventContainer.jsx
+++ b/cosc360-rsvp/client/src/features/event/homepageEvents/EventContainer.jsx
@@ -14,7 +14,7 @@ function averageRating(reviews) {
   return (sum / reviews.length);
 }
 
-const EventContainer = ({ events, onEventClick, showReviewButton, onReviewClick, onEditClick, showDeleteRsvpButton, onDeleteRsvpClick }) => {
+const EventContainer = ({ events, onEventClick, showReviewButton, onReviewClick, onEditClick, showDeleteRsvpButton, onDeleteRsvpClick, onSavedStateChange }) => {
   const [savedEventIds, setSavedEventIds] = useState(new Set());
   const { activeUserId } = useAuth();
 
@@ -67,6 +67,7 @@ const EventContainer = ({ events, onEventClick, showReviewButton, onReviewClick,
 
       return next;
     });
+    onSavedStateChange?.(eventId, isWishlisted);
   }
 
   return (

--- a/cosc360-rsvp/client/src/pages/event.jsx
+++ b/cosc360-rsvp/client/src/pages/event.jsx
@@ -204,7 +204,7 @@ function EventPage() {
         return (
             <div className="homepage-layout">
                 {showLogin && <LoginOverlay onClose={() => setShowLogin(false)}/>}
-                <Sidebar />
+                {activeUser?.role === "admin" ? <AdminSidebar /> : <Sidebar />}
                 <div className="main-content">
                     <TopNav />
                     <div className="main-content-area">
@@ -218,8 +218,7 @@ function EventPage() {
     return (
         <div className="homepage-layout">
             {showLogin && <LoginOverlay onClose={() => setShowLogin(false)}/>}
-            <Sidebar />
-            {activeUser?.role === 'admin' ? (<AdminSidebar />) : (<Sidebar />)}
+            {activeUser?.role === "admin" ? <AdminSidebar /> : <Sidebar />}
             <div className="main-content">
                 <TopNav />
                 <div id="event-header">

--- a/cosc360-rsvp/client/src/pages/savedEvents.jsx
+++ b/cosc360-rsvp/client/src/pages/savedEvents.jsx
@@ -21,6 +21,17 @@ function SavedEvents() {
         navigate(`/event/${eventId}`);
     }
 
+    function handleSavedStateChange(eventId, isWishlisted) {
+        if (isWishlisted) return;
+
+        setSavedEvents((prev) =>
+            prev.filter((event) => {
+                const id = event?._id?.toString?.() || event?.id?.toString?.();
+                return id !== eventId;
+            })
+        );
+    }
+
     useEffect(() => {
         async function fetchSavedEvents() {
             if (!activeUserId) {
@@ -79,7 +90,11 @@ function SavedEvents() {
                 ) : savedEvents.length === 0 ? (
                     <p style={{ marginLeft: "24px" }}>No saved events yet.</p>
                 ) : (
-                    <EventContainer events={savedEvents} onEventClick={handleEventClick} />
+                    <EventContainer
+                        events={savedEvents}
+                        onEventClick={handleEventClick}
+                        onSavedStateChange={handleSavedStateChange}
+                    />
                 )}
             </div>
         </div>

--- a/cosc360-rsvp/client/src/tests/SavedEvents.frontend.test.jsx
+++ b/cosc360-rsvp/client/src/tests/SavedEvents.frontend.test.jsx
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import SavedEvents from "../pages/savedEvents.jsx";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useAuth } from "../context/AuthContext.jsx";
+
+jest.mock("react-router-dom", () => ({
+    useNavigate: jest.fn(),
+    useSearchParams: jest.fn(),
+}));
+
+jest.mock("../context/AuthContext.jsx", () => ({
+    useAuth: jest.fn(),
+}));
+
+jest.mock("../components/topNav", () => () => <div>TopNav</div>);
+jest.mock("../components/sidebar", () => () => <div>Sidebar</div>);
+jest.mock("../components/AdminSidebar", () => () => <div>AdminSidebar</div>);
+
+jest.mock("../features/event/homepageEvents/EventContainer", () => {
+    return function MockEventContainer({ events, onSavedStateChange }) {
+        return (
+            <div>
+                <div>EventContainer</div>
+                {events.map((event) => (
+                    <p key={event._id}>{event.name}</p>
+                ))}
+                <button
+                    onClick={() => {
+                        if (!events[0]) return;
+                        onSavedStateChange?.(events[0]._id, false);
+                    }}
+                >
+                    Unsave first
+                </button>
+            </div>
+        );
+    };
+});
+
+describe("SavedEvents page frontend tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        global.fetch = jest.fn();
+        useNavigate.mockReturnValue(jest.fn());
+        useSearchParams.mockReturnValue([new URLSearchParams("")]);
+        useAuth.mockReturnValue({
+            activeUser: { role: "user" },
+            activeUserId: "user_1",
+        });
+    });
+
+    // tests saved-events load path, page should render saved items from RSVP payload
+    test("shows saved events after fetch completes", async () => {
+        global.fetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                events: [
+                    { eventId: { _id: "event_1", name: "Saved Music Night" } },
+                    { eventId: { _id: "event_2", name: "Saved Coding Meetup" } },
+                ],
+            }),
+        });
+
+        render(<SavedEvents />);
+
+        expect(screen.getByText("Loading...")).toBeInTheDocument();
+        expect(await screen.findByText("Saved Music Night")).toBeInTheDocument();
+        expect(screen.getByText("Saved Coding Meetup")).toBeInTheDocument();
+        expect(global.fetch).toHaveBeenCalledWith("/api/rsvp/events?status=saved", {
+            headers: { "x-user-id": "user_1" },
+        });
+    });
+
+    // tests empty-state path, should show empty message when there are no saved events
+    test("shows empty state when user has no saved events", async () => {
+        global.fetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({ events: [] }),
+        });
+
+        render(<SavedEvents />);
+
+        expect(await screen.findByText("No saved events yet.")).toBeInTheDocument();
+    });
+
+    // tests unsave behavior, removing first saved event should update the page list
+    test("removes event from list when unsaved from saved page", async () => {
+        global.fetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                events: [
+                    { eventId: { _id: "event_1", name: "Saved Music Night" } },
+                    { eventId: { _id: "event_2", name: "Saved Coding Meetup" } },
+                ],
+            }),
+        });
+
+        render(<SavedEvents />);
+
+        expect(await screen.findByText("Saved Music Night")).toBeInTheDocument();
+        expect(screen.getByText("Saved Coding Meetup")).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText("Unsave first"));
+
+        expect(screen.queryByText("Saved Music Night")).not.toBeInTheDocument();
+        expect(screen.getByText("Saved Coding Meetup")).toBeInTheDocument();
+    });
+});

--- a/cosc360-rsvp/server/src/tests/rsvp.test.js
+++ b/cosc360-rsvp/server/src/tests/rsvp.test.js
@@ -244,3 +244,71 @@ describe("Integration for PATCH /api/rsvp/:eventId (declineRSVP)", () => {
         expect(res.body.error).toBe("You have not RSVP'd 'yes' to this event, so there is no RSVP to cancel");
     });
 });
+
+// Integration tests for saved RSVP flows
+describe("Integration for saved RSVP routes", () => {
+    test("returns only saved events for the user", async () => {
+        const user = await createUser();
+        const eventSaved = await createEvent(user._id, { name: "Saved Only Event" });
+        const eventYes = await createEvent(user._id, { name: "Yes RSVP Event" });
+
+        await createRSVP(user._id, eventSaved._id, "saved");
+        await createRSVP(user._id, eventYes._id, "yes");
+
+        const res = await request(app)
+            .get("/api/rsvp/events?status=saved")
+            .set("x-user-id", user._id.toString());
+
+        expect(res.statusCode).toBe(200);
+        expect(Array.isArray(res.body.events)).toBe(true);
+        expect(res.body.events).toHaveLength(1);
+        expect(res.body.events[0].status).toBe("saved");
+        expect(res.body.events[0].eventId.name).toBe("Saved Only Event");
+    });
+
+    test("filters saved events by search query", async () => {
+        const user = await createUser();
+        const eventMusic = await createEvent(user._id, { name: "Saved Music Night" });
+        const eventCode = await createEvent(user._id, { name: "Saved Coding Meetup" });
+
+        await createRSVP(user._id, eventMusic._id, "saved");
+        await createRSVP(user._id, eventCode._id, "saved");
+
+        const res = await request(app)
+            .get("/api/rsvp/events?status=saved&q=music")
+            .set("x-user-id", user._id.toString());
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.events).toHaveLength(1);
+        expect(res.body.events[0].eventId.name).toBe("Saved Music Night");
+    });
+
+    test("updates RSVP from yes to saved", async () => {
+        const user = await createUser();
+        const event = await createEvent(user._id, { name: "Switch To Saved Event" });
+        await createRSVP(user._id, event._id, "yes");
+
+        const res = await request(app)
+            .put(`/api/rsvp/${event._id}`)
+            .set("x-user-id", user._id.toString())
+            .send({ status: "saved" });
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.message).toBe("RSVP updated successfully!");
+        expect(res.body.event.status).toBe("saved");
+    });
+
+    test("blocks creating saved RSVP when user already RSVP'd yes", async () => {
+        const user = await createUser();
+        const event = await createEvent(user._id, { name: "Already Yes Event" });
+        await createRSVP(user._id, event._id, "yes");
+
+        const res = await request(app)
+            .post("/api/rsvp")
+            .set("x-user-id", user._id.toString())
+            .send({ eventId: event._id.toString(), status: "saved" });
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body.error).toBe("You have already RSVP'd to this event!");
+    });
+});


### PR DESCRIPTION
I finished off the saved event tests:

Tests added:
tested that saved events actually show on the saved events page
tested empty state on saved events page
tested that unsaving removes the event from that page list
tested backend saved RSVP route returns only saved items
tested backend saved RSVP search query filtering
tested updating RSVP from yes to saved
tested blocking a saved RSVP create if user already RSVP’d yes

Also fixed:
caught a UI/state issue where unsaving on the saved events page did not remove the event right away
fixed it by sending save-state changes up from EventContainer and updating savedEvents page state immediately




this issue trey fixed before came back after merging multiple event.jsx.   ive fixed it now.

<img width="1512" height="827" alt="Screenshot 2026-04-10 at 6 24 00 PM" src="https://github.com/user-attachments/assets/63be70d8-2ada-4288-9642-71e5ab45c291" />
