### PR TITLE
fix warnings in tests

### DIFF
--- a/cosc360-rsvp/client/src/tests/MyEvents.frontend.test.jsx
+++ b/cosc360-rsvp/client/src/tests/MyEvents.frontend.test.jsx
@@ -32,6 +32,12 @@ jest.mock("../features/event/homepageEvents/EventContainer", () => ({ events, on
 ));
 jest.mock("../css/Home.css", () => ({}));
 
+async function waitForMyEventsLoadingToFinish() {
+    await waitFor(() => {
+        expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+    });
+}
+
 describe("MyEvents frontend tests", () => {
     const mockNavigate = jest.fn();
 
@@ -65,6 +71,8 @@ describe("MyEvents frontend tests", () => {
         expect(screen.getByText("Upcoming Attending Events")).toBeInTheDocument();
         expect(screen.getByText("Previously Hosted Events")).toBeInTheDocument();
         expect(screen.getByText("Previously Attended Events")).toBeInTheDocument();
+
+        await waitForMyEventsLoadingToFinish();
     });
 
     // tests loading state, page should show loading text before data arrives
@@ -107,6 +115,8 @@ describe("MyEvents frontend tests", () => {
                 headers: { "x-user-id": "user_1" },
             });
         });
+
+        await waitForMyEventsLoadingToFinish();
     });
 
     // tests logged-out guard, no fetches should happen without an active user
@@ -160,6 +170,7 @@ describe("MyEvents frontend tests", () => {
         fireEvent.click(viewButton);
 
         expect(mockNavigate).toHaveBeenCalledWith("/event/event_1");
+        await waitForMyEventsLoadingToFinish();
     });
 
     // tests RSVP cancellation, should send PATCH with correct user header
@@ -208,6 +219,8 @@ describe("MyEvents frontend tests", () => {
                 },
             });
         });
+
+        await waitForMyEventsLoadingToFinish();
     });
 
     // tests review modal, clicking review on a past event should open the modal
@@ -246,5 +259,7 @@ describe("MyEvents frontend tests", () => {
         await waitFor(() => {
             expect(screen.getByText("ReviewModal")).toBeInTheDocument();
         });
+
+        await waitForMyEventsLoadingToFinish();
     });
 });


### PR DESCRIPTION
just cleaned up some noisy react act(...) warnings in the myevents frontend tests.

the tests were already passing, but they were finishing before async state updates settled, so the output looked messy.
- added a small helper to wait until loading is done
- used that in the async myevents tests so they fully settle before finishing
- no behavior changes, just cleaner/more stable test output to get rid of thoose warnings.